### PR TITLE
[FEATURE] Disabling property "source" when it is empty

### DIFF
--- a/src/PipelineR/ErrorResult.cs
+++ b/src/PipelineR/ErrorResult.cs
@@ -28,6 +28,7 @@ namespace PipelineR
         public string Source { get; private set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Message { get; private set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public Exception Exception { get; private set; }
 
     }

--- a/src/PipelineR/ErrorResult.cs
+++ b/src/PipelineR/ErrorResult.cs
@@ -11,7 +11,7 @@ namespace PipelineR
             this.Source = source;
             this.Message = message;
         }
-        public ErrorResult(string source, Exception exception):this(source,String.Empty,exception) {
+        public ErrorResult(string source, Exception exception):this(source,null,exception) {
 
         }
         public ErrorResult(string source, string message):this(source,message,null) {
@@ -20,12 +20,13 @@ namespace PipelineR
         public ErrorResult( string message):this(null, message, null) {
 
         }
-        public ErrorResult( Exception exception):this(string.Empty,string.Empty,exception) {
+        public ErrorResult( Exception exception):this(null, null, exception) {
 
         }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Source { get; private set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Message { get; private set; }
         public Exception Exception { get; private set; }
 

--- a/src/PipelineR/ErrorResult.cs
+++ b/src/PipelineR/ErrorResult.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 
 namespace PipelineR
 {
@@ -16,12 +17,14 @@ namespace PipelineR
         public ErrorResult(string source, string message):this(source,message,null) {
 
         }
-        public ErrorResult( string message):this(String.Empty,message,null) {
+        public ErrorResult( string message):this(null, message, null) {
 
         }
         public ErrorResult( Exception exception):this(string.Empty,string.Empty,exception) {
 
         }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Source { get; private set; }
         public string Message { get; private set; }
         public Exception Exception { get; private set; }

--- a/src/PipelineR/Pipeline.cs
+++ b/src/PipelineR/Pipeline.cs
@@ -34,8 +34,7 @@ namespace PipelineR
 
             return this;
         }
-        public Pipeline<TContext, TRequest> AddValidator(IValidator<TRequest> validator)
-        {
+        public Pipeline<TContext, TRequest> AddValidator(IValidator<TRequest> validator) {
             _validator = validator;
             return this;
         }
@@ -50,7 +49,7 @@ namespace PipelineR
                 if (validateResult.IsValid == false)
                 {
                     var errors = (validateResult.Errors.Select(p => new ErrorResult(p.ErrorMessage))).ToList();
-                    return new RequestHandlerResult(errors);
+                    return new RequestHandlerResult(errors, 412);
                 }
                     
             }

--- a/src/PipelineR/PipelineR.csproj
+++ b/src/PipelineR/PipelineR.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
       <PackageReference Include="FluentValidation" Version="8.5.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Whats ?
 Disable property "source" when it comes empty in ErrorResult constructor

## How ? 
When it comes empty,  its passed null in the standard constructor 
Just added a JsonProperty that when it comes null, it's ignored in the response body.