### PR TITLE
[Feature] Updates StackExchange

### DIFF
--- a/src/PipelineR/PipelineR.csproj
+++ b/src/PipelineR/PipelineR.csproj
@@ -21,7 +21,7 @@
       <PackageReference Include="PackUtils" Version="1.0.72" />
       <PackageReference Include="Polly" Version="7.2.0" />
       <PackageReference Include="Serilog" Version="2.10.0" />
-      <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
+      <PackageReference Include="StackExchange.Redis" Version="2.2.88" />
       <PackageReference Include="StackExchange.Redis.Extensions.Core" Version="7.0.0-pre" />
       <PackageReference Include="StackExchange.Redis.Extensions.Newtonsoft" Version="7.0.0-pre" />
       <PackageReference Include="WebApi.Models" Version="1.0.12" />


### PR DESCRIPTION
### Whats?
- Updates StackExchange version to 2.2.88 because erlier version than 2.2.5 were with a bug of connection to redis.