### PR TITLE
Return error result when exception

### DIFF
--- a/src/PipelineR.Sample/PipelineR.Sample.csproj
+++ b/src/PipelineR.Sample/PipelineR.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/src/PipelineR.Test/PipelineR.Test.csproj
+++ b/src/PipelineR.Test/PipelineR.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/PipelineR.Test/PipelineTests.cs
+++ b/src/PipelineR.Test/PipelineTests.cs
@@ -134,5 +134,26 @@ namespace PipelineR.Test
             Assert.False(context.UpdateAccountRecoveryHandlerWasExecuted);
             Assert.False(context.CreateUserApiFourRecoveryHandlerWasExecuted);
         }
+
+        [Fact]
+        public void Should_return_errorResult_when_exception()
+        {
+            var context = new ContextSample();
+            var request = new SampleRequest();
+
+            var pipeline = new Pipeline<ContextSample, SampleRequest>()
+                .AddNext(new InitializeCreateUserHandler(context))
+                .AddNext(new CreateUserApiOneHandler(context))
+                .AddNext(new CreateUserApiTwoHandler(context))
+                .AddNext(new UpdateAccountHandler(context))
+                .AddNext(new CreateUserApiThreeHandler(context))
+                .AddNext(new CreateUserApiThreeDotOneHandler(context))
+                .AddNext(new CreateUserApiFourHandler(context))
+                .Execute(request);
+
+            Assert.False(pipeline.IsSuccess());
+            Assert.Equal(500, pipeline.StatusCode);
+            Assert.Equal(1, pipeline.Errors.Count);
+        }
     }
 }

--- a/src/PipelineR.Test/RequestHandlers/CreateUserApiThreeDotOneHandler.cs
+++ b/src/PipelineR.Test/RequestHandlers/CreateUserApiThreeDotOneHandler.cs
@@ -1,0 +1,20 @@
+﻿using PipelineR.Test.Request;
+using System;
+
+namespace PipelineR.Test.RequestHandlers
+{
+    internal class CreateUserApiThreeDotOneHandler: RequestHandler<ContextSample, SampleRequest>, ICreateUserApiOneHandler
+    {
+        public CreateUserApiThreeDotOneHandler(ContextSample context) : base(context)
+        {
+        }
+
+        public override RequestHandlerResult HandleRequest(SampleRequest request)
+        {
+            throw new Exception("Exception inside RequestHandler");
+        }
+    }
+
+    public interface ICreateUserApiThreeDotOneHandler : IRequestHandler<ContextSample, SampleRequest>
+    { }
+}

--- a/src/PipelineR/ContextConverter.cs
+++ b/src/PipelineR/ContextConverter.cs
@@ -1,32 +1,27 @@
 ﻿using Microsoft.Extensions.DependencyModel;
-using PackUtils.Converters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
 namespace PipelineR
 {
-    public class ContextConverter: JsonObjectCreationConverter<BaseContext>
+    public class ContextConverter : JsonObjectCreationConverter<BaseContext>
     {
         public ContextConverter()
         {
+            var contexts = this.GetAssemblies().SelectMany(p => p.GetTypes())
+                .Where(p => p.GetTypeInfo().BaseType == typeof(BaseContext));
 
-            var contexts= this.GetAssemblies().SelectMany(p=>p.GetTypes())
-                                    .Where(p => p.GetTypeInfo().BaseType == typeof(BaseContext));
-            
             this.Property = "Id";
             this.TypesMapping = new Dictionary<string, Type>();
 
-            foreach(var context in contexts)
+            foreach (var context in contexts)
             {
                 this.TypesMapping.Add(context.FullName, context.UnderlyingSystemType);
             }
         }
 
-
-       
         private Assembly[] GetAssemblies()
         {
             var assemblies = new List<Assembly>();

--- a/src/PipelineR/JsonObjectCreationConverter.cs
+++ b/src/PipelineR/JsonObjectCreationConverter.cs
@@ -1,0 +1,53 @@
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System;
+using Newtonsoft.Json;
+
+namespace PipelineR;
+
+public abstract class JsonObjectCreationConverter<TEntity> : JsonConverter
+{
+    public string Property { get; set; }
+
+    public Dictionary<string, Type> TypesMapping { get; set; }
+
+    protected TEntity Create(Type objectType, JObject jsonObject)
+    {
+        JToken token;
+        if (!jsonObject.TryGetValue(this.Property, out token))
+        {
+            return (TEntity)Activator.CreateInstance(objectType);
+        }
+
+        foreach (var type in this.TypesMapping)
+        {
+            if (type.Key.Equals(token.ToString()))
+            {
+                return (TEntity)Activator.CreateInstance(type.Value);
+            }
+        }
+
+        return (TEntity)Activator.CreateInstance(objectType);
+    }
+
+    public override bool CanConvert(Type objectType)
+    {
+        return typeof(TEntity).IsAssignableFrom(objectType);
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType,
+        object existingValue, JsonSerializer serializer)
+    {
+        var jsonObject = JObject.Load(reader);
+        var target = Create(objectType, jsonObject);
+        serializer.Populate(jsonObject.CreateReader(), target);
+        return target;
+    }
+
+    public override bool CanWrite { get { return false; } }
+
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/PipelineR/Pipeline.cs
+++ b/src/PipelineR/Pipeline.cs
@@ -316,6 +316,7 @@ namespace PipelineR
                         Log.Logger.Error(ex, string.Concat("Error - ", this._requestHandler.Context.CurrentRequestHandleId));
                     }
                 }
+                result = new RequestHandlerResult(new ErrorResult(ex.Source, ex.GetBaseException().Message, ex, null, null), 500);
             }
             finally
             {

--- a/src/PipelineR/PipelineR.csproj
+++ b/src/PipelineR/PipelineR.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <AssemblyName>PipelineR</AssemblyName>
         <RootNamespace>PipelineR</RootNamespace>
         <PackageId>PipelineR</PackageId>
@@ -10,6 +10,7 @@
         <Product>PipelineR</Product>
         <PackageVersion>1.7.0</PackageVersion>
         <Version>2.0.0</Version>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,8 +18,8 @@
       <PackageReference Include="JsonNet.PrivateSettersContractResolvers" Version="1.0.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0-preview.5.20278.1" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-      <PackageReference Include="PackUtils" Version="1.0.72" />
       <PackageReference Include="Polly" Version="7.2.0" />
       <PackageReference Include="Serilog" Version="2.10.0" />
       <PackageReference Include="StackExchange.Redis" Version="2.1.58" />

--- a/src/PipelineR/PipelineR.csproj
+++ b/src/PipelineR/PipelineR.csproj
@@ -8,7 +8,7 @@
         <Authors>PipelineR</Authors>
         <Company>PipelineR</Company>
         <Product>PipelineR</Product>
-        <PackageVersion>1.6.0</PackageVersion>
+        <PackageVersion>1.7.0</PackageVersion>
         <Version>2.0.0</Version>
     </PropertyGroup>
 


### PR DESCRIPTION
PipelineR retorna nulo quando acontece uma exception dentro de um handler, o que gera confusão nas aplicações que usam o PipelineR e faz com que a exception que aconteceu dentro do PipelineR fique perdida, dificultando analisar os logs. Além de ser uma boa prática evitar retornar nulo, como por exemplo na CS8603.

O código proposto simplesmente criar um ErrorResult contendo a mensagem do erro e toda a Exception. Sendo assim, a aplicação que usa o PipelineR consegue saber exatamente o que aconteceu dentro da step, um problema no banco de dados? Erro de conversão? etc.